### PR TITLE
Change joi to @hapi/joi (also upgrade it to latest version)

### DIFF
--- a/manifest-utils/validate.js
+++ b/manifest-utils/validate.js
@@ -1,4 +1,4 @@
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const chalk = require('chalk')
 
 const schema = Joi.object({

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.1",
-    "joi": "^13.3.0",
+    "@hapi/joi": "^15.0.1",
     "ws": "^5.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
joi is deprecated and moved to hapijs/joi
This PR corrects the dependency and also upgrades it to the latest version.

Fixes #17 
Closes #11 