### PR TITLE
Fix file reload matching workflow

### DIFF
--- a/client.js
+++ b/client.js
@@ -4,6 +4,7 @@
   const port = /* PLACEHOLDER-PORT */ 35729 /* PLACEHOLDER-PORT */
   const reconnectTime = /* PLACEHOLDER-RECONNECTTIME */ 3000 /* PLACEHOLDER-RECONNECTTIME */
   const quiet = /* PLACEHOLDER-QUIET */ false /* PLACEHOLDER-QUIET */
+  const fileRegex = /[^"]*\.[a-zA-Z]+/g
 
   connect()
 
@@ -119,7 +120,6 @@
   function getManifestFileDeps () {
     const manifest = (browser || chrome).runtime.getManifest()
     const manifestStr = JSON.stringify(manifest)
-    const fileRegex = /[^"]*\.[a-zA-Z]+/g
     return manifestStr.match(fileRegex)
   }
 

--- a/client.js
+++ b/client.js
@@ -120,7 +120,7 @@
   function getManifestFileDeps () {
     const manifest = (browser || chrome).runtime.getManifest()
     const manifestStr = JSON.stringify(manifest)
-    return manifestStr.match(fileRegex)
+    return manifestStr.match(fileRegex) || []
   }
 
   /**


### PR DESCRIPTION
### Key Changes

- Initializes `fileRegex` at the root plugin scope, instead of computing at every function call
- In case the `.match` function returns `null` (no matches) — return an empty array from `getManifestDeps` to make sure `.some` can be called on it.

### Secondary Changes

N/A


