### PR TITLE
Add the support for the 'safari' keyword.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Any of the options below.
 
 Type: `String`  
 Default: `chrome`  
-Any of: `chrome`, `opera`, `firefox`, `edge`
+Any of: `chrome`, `opera`, `firefox`, `edge`, `safari`
 
 Used for vendor prefixing in the `manifest.json`. More infos regarding this can be found below.
 
@@ -109,7 +109,8 @@ Vendor prefixed manifest keys allow you to write one `manifest.json` for multibl
   "__chrome__name": "SuperChrome",
   "__firefox__name": "SuperFox",
   "__edge__name": "SuperEdge",
-  "__opera__name": "SuperOpera"
+  "__opera__name": "SuperOpera",
+  "__safari__name": "SuperSafari"
 }
 ```
 

--- a/manifest-utils/transform-vendor-keys.test.js
+++ b/manifest-utils/transform-vendor-keys.test.js
@@ -48,3 +48,25 @@ test('removes unused nested vendor keys', () => {
   const result = transformVendorKeys(manifest, 'chrome')
   expect(result.browser_action.theme_icons).toBeUndefined()
 })
+
+test('transform safari keys correctly', () => {
+  const manifest = {
+    version: '42.0.0',
+    name: 'left-pad',
+    __safari__name: 'safari-pad'
+  }
+  const result = transformVendorKeys(manifest, 'safari')
+  expect(result.name).toEqual(manifest.__safari__name)
+})
+
+test('transform combined keys correctly', () => {
+  const manifest = {
+    version: '42.0.0',
+    name: 'left-pad',
+    "__safari|opera__name": 'pad'
+  }
+  const resultSafari = transformVendorKeys(manifest, 'safari')
+  const resultOpera = transformVendorKeys(manifest, 'opera')
+  expect(resultSafari.name).toEqual(manifest["__safari|opera__name"])
+  expect(resultOpera.name).toEqual(manifest["__safari|opera__name"])
+})

--- a/vendors.json
+++ b/vendors.json
@@ -2,5 +2,6 @@
   "chrome",
   "firefox",
   "opera",
-  "edge"
+  "edge",
+  "safari"
 ]


### PR DESCRIPTION
This is a PR for the issue '[Safari Support #373](https://github.com/webextension-toolbox/webextension-toolbox/issues/373)' of the [webextension-toolbox ](https://github.com/webextension-toolbox/webextension-toolbox)project. 
Apparently, I need to change code in this repo in order to fix the original issue. Please accept my PR, then I will take a follow-up in the webextension-toolbox. 
Thank you.