### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm i @webextension-toolbox/webextension-toolbox
 ## Usage
 
 ```js
-const WebextensionPlugin = require("webpack-webextension-plugin");
+import WebextensionPlugin from "@webextension-toolbox/webpack-webextension-plugin";
 
 const config = {
   plugins: [


### PR DESCRIPTION
The current README instructions don't work. Wrong package name is listed, and the `@webextension-toolbox/webpack-webextension-plugin` export is using ESM so you either need to use the `import` statement, or suffix things with `.default`.